### PR TITLE
Bump hashicorp/azurerm from 4.2.0 to 4.14.0 in /code/infra

### DIFF
--- a/code/infra/terraform.tf
+++ b/code/infra/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "4.2.0"
+      version = "4.14.0"
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
**Proposed changes**:
- Bump hashicorp/azurerm from 4.2.0 to 4.14.0 in /code/infra
